### PR TITLE
Optimising ScrollPanel to skip rendering components outside its bounds

### DIFF
--- a/src/main/java/de/erdbeerbaerlp/guilib/components/ScrollPanel.java
+++ b/src/main/java/de/erdbeerbaerlp/guilib/components/ScrollPanel.java
@@ -138,7 +138,12 @@ public class ScrollPanel extends GuiComponent {
         for (final GuiComponent c : components) {
             c.scrollOffsetY = this.getY() - (int) scrollDistance;
             c.scrollOffsetX = this.getX();
-            if (c.isVisible()) c.render(matrixStack, mouseX, mouseY, partialTicks);
+            if (c.isVisible()
+                    && c.getY() < this.getY() + this.getHeight()
+                    && c.getY() + c.getHeight() > this.getY()
+            ) {
+                c.render(matrixStack, mouseX, mouseY, partialTicks);
+            }
         }
     }
 


### PR DESCRIPTION
Adding many items to the ScrollPanel makes it very sluggish. This PR fixes that by skipping the views that are not visible from being rendered